### PR TITLE
マークダウンレイアウトにベースレイアウトを適用

### DIFF
--- a/src/layouts/MarkdownPostLayout.astro
+++ b/src/layouts/MarkdownPostLayout.astro
@@ -1,10 +1,13 @@
 ---
+import BaseLayout from './BaseLayout.astro'
+
 const { frontmatter } = Astro.props
 ---
 
-<h1>{frontmatter.title}</h1>
-<p>著者: {frontmatter.author}</p>
-<p><em>{frontmatter.description}</em></p>
-<p>投稿日: {frontmatter.pubDate.slice(0, 10)}</p>
-<img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
-<slot />
+<BaseLayout pageTitle={frontmatter.title}>
+  <p>著者: {frontmatter.author}</p>
+  <p><em>{frontmatter.description}</em></p>
+  <p>投稿日: {frontmatter.pubDate.slice(0, 10)}</p>
+  <img src={frontmatter.image.url} width="300" alt={frontmatter.image.alt} />
+  <slot />
+</BaseLayout>


### PR DESCRIPTION
# what

- 現状のマークダウンのレイアウトに、通常ページのレイアウトであるBaseLayoutを適用した

# test

- ブログ記事のページに移動し、通常ページと同様のデザインとなっているか確認する
- `/posts/post-{hogehoge}/`