### PR TITLE
タグ一覧ページを追加

### DIFF
--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,28 @@
+---
+import BlogPost from '../../components/BlogPost.astro'
+import BaseLayout from '../../layouts/BaseLayout.astro'
+
+export async function getStaticPaths() {
+  const allPosts = await Astro.glob('../posts/*.md')
+  const uniqueTags = [...new Set(allPosts.map((post) => post.frontmatter.tags).flat())]
+
+  return uniqueTags.map((tag) => {
+    const filteredPosts = allPosts.filter((post) => post.frontmatter.tags.includes(tag))
+
+    return {
+      params: { tag },
+      props: { posts: filteredPosts },
+    }
+  })
+}
+
+const { tag } = Astro.params
+const { posts } = Astro.props
+---
+
+<BaseLayout pageTitle={tag}>
+  <p>{tag}のタグが付いた記事</p>
+  <ul>
+    {posts.map((post) => <BlogPost url={post.url} title={post.frontmatter.title} />)}
+  </ul>
+</BaseLayout>


### PR DESCRIPTION
# what

- 今までの記事の各タグのページを追加
- getStaticPathsを使って、動的に各タグを持っている記事を抽出するページを実装した

# test

- `http://localhost:4321/tags/astro`ページに移動し、astroタグを含む記事が出てくるか